### PR TITLE
Add Onramp OSC Update Handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIBROARING=vendor/OSMExpress/vendor/CRoaring/src/libroaring.a
 LIBS2=vendor/OSMExpress/vendor/s2geometry/libs2.a
 
 OSMEXPRESS_SOURCE_FILES=./vendor/OSMExpress/src/storage.cpp
-SOURCE_FILES=./src/main.cpp ./src/osmx_update_handler.cpp $(OSMEXPRESS_SOURCE_FILES)
+SOURCE_FILES=./src/main.cpp ./src/osmx_update_handler.cpp ./src/onramp_update_handler.cpp $(OSMEXPRESS_SOURCE_FILES)
 
 $(LIBLMDB) $(LIBCAPNP) $(LIBKJ) $(LIBROARING) $(LIBS2):
 	cd vendor/OSMExpress && \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include "osmium/io/any_input.hpp"
 #include "osmx/storage.h"
 
-#include "./osmx_update_handler.cpp"
+#include "./onramp_update_handler.cpp"
 
 using namespace std;
 
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
   const osmium::io::File input_file{osc};
 
   osmium::io::Reader reader{input_file, osmium::osm_entity_bits::object};
-  OsmxUpdateHandler handler(txn);
+  OnrampUpdateHandler handler(txn);
   osmium::apply(reader, handler);
 
   auto duration = (std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::high_resolution_clock::now() - startTime ).count()) / 1000.0;

--- a/src/onramp_update_handler.cpp
+++ b/src/onramp_update_handler.cpp
@@ -1,0 +1,20 @@
+#include "./osmx_update_handler.cpp"
+
+class OnrampUpdateHandler : public OsmxUpdateHandler {
+
+public:
+  OnrampUpdateHandler(MDB_txn *txn) : OsmxUpdateHandler(txn) {};
+
+  // The oldNode is coming from osmx and will only contain an id and location
+  virtual void node_changed(const osmium::Node& newNode, const osmium::Location& oldLocation) {
+    cout << "NODE CHANGED: " << newNode.id() << " to v" << newNode.version() << endl;
+  }
+
+  virtual void node_added(const osmium::Node& newNode) {
+    cout << "NODE ADDED: " << to_string(newNode.id()) << endl;
+  }
+
+  virtual void node_deleted(const osmium::Node& oldNode) {
+    cout << "NODE DELETED: " << to_string(oldNode.id()) << endl;
+  }
+};

--- a/src/osmx_update_handler.cpp
+++ b/src/osmx_update_handler.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 
 class OsmxUpdateHandler : public osmium::handler::Handler {
-  public:
+public:
   OsmxUpdateHandler(MDB_txn *txn) :
   mTxn(txn),
   mLocations(txn),
@@ -23,18 +23,17 @@ class OsmxUpdateHandler : public osmium::handler::Handler {
   mRelationRelation(txn, "relation_relation")  {
   }
 
-  // The oldNode is coming from osmx and will only contain an id and location
-  virtual void node_changed(const osmium::Node& newNode, const osmium::Location& oldLocation) {
-    cout << "NODE CHANGED: " << newNode.id() << " to v" << newNode.version() << endl;
-  }
+  /** START HOOKS
+   * Default hook implementation is for each to NOOP
+   */
 
-  virtual void node_added(const osmium::Node& newNode) {
-    cout << "NODE ADDED: " << to_string(newNode.id()) << endl;
-  }
+  virtual void node_changed(const osmium::Node& newNode, const osmium::Location& oldLocation) {}
 
-  virtual void node_deleted(const osmium::Node& oldNode) {
-    cout << "NODE DELETED: " << to_string(oldNode.id()) << endl;
-  }
+  virtual void node_added(const osmium::Node& newNode) {}
+
+  virtual void node_deleted(const osmium::Node& oldNode) {}
+
+  /** END HOOKS */
 
   // update location, node, cell_location tables
   void node(const osmium::Node& node) {
@@ -215,7 +214,7 @@ class OsmxUpdateHandler : public osmium::handler::Handler {
     }
   }
 
-  private:
+private:
   MDB_txn *mTxn;
   osmx::db::Locations mLocations;
   osmx::db::Elements mNodes;


### PR DESCRIPTION
Copies the osmx_update_handler.cpp from https://github.com/protomaps/OSMExpress/blob/master/src/update.cpp and adds a set of hook methods that can be overridden to handle the cases of each entity being added, changed, or deleted. Only implemented for nodes for now, and its likely that we'll need to tweak the logic for where these are called based on the TODO before adding the rest for ways and relations.

Adds onramp_update_handler which extends the osmx_update_handler to just print the node id and the operation being performed. These handlers are where we'll generate each individual chunk of the augmented diff

Cleans up Makefile based on comments provided in #6 

Going to merge right away to continue forward.