### PR TITLE
Add tooling for a reproducible EC2 instance with daemonized osmx-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+cloud-config.yml

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,8 +1,8 @@
 # Deployment
 
 This document walks through instantiating an EC2 instance that will contain a
-copy of this repository, as well as a background daemon will update the OSMX
-database using the minutely diffs of `planet.osm` [provided by
+copy of this repository, as well as a background daemon that will update the
+OSMX database using the minutely diffs of `planet.osm` [provided by
 OpenStreetMap](https://planet.openstreetmap.org/replication/minute/).
 
 An AWS account with an existing EBS snapshot containing a `planet.osmx` database

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,37 @@
+# Deployment
+
+This document walks through instantiating an EC2 instance that will contain a
+copy of this repository, as well as a background daemon will update the OSMX
+database using the minutely diffs of `planet.osm` [provided by
+OpenStreetMap](https://planet.openstreetmap.org/replication/minute/).
+
+An AWS account with an existing EBS snapshot containing a `planet.osmx` database
+file is required.
+
+## Workflow
+
+The following AWS CLI command will instantiate the EC2 instance. You will have
+to substitute your own key name, security group, subnet ID, and snapshot ID.
+
+```bash
+aws ec2 run-instances \
+    --image-id ami-0bcc094591f354be2 \
+    --count 1 \
+    --instance-type t3.xlarge \
+    --key-name joker \
+    --security-group-ids sg-joker \
+    --subnet-id subnet-joker \
+    --block-device-mappings "[{\"DeviceName\":\"/dev/sdf\",\"Ebs\":{\"SnapshotId\":\"snap-joker\"}}]" \
+    --user-data file://cloud-config.yml
+```
+
+After the EC2 instance is online, you can follow the progress of `osmx-update`
+with the following command:
+
+```bash
+$ tail -f /var/log/syslog
+Aug 31 23:48:56 ip-10-0-1-70 osmx-update: Committed: 3985436 -> 3985437 in 17.995 seconds.
+Aug 31 23:49:18 ip-10-0-1-70 osmx-update: Committed: 3985437 -> 3985438 in 21.765 seconds.
+Aug 31 23:49:48 ip-10-0-1-70 osmx-update: Committed: 3985438 -> 3985439 in 29.088 seconds.
+. . .
+```

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -28,10 +28,10 @@ aws ec2 run-instances \
     --image-id ami-0bcc094591f354be2 \
     --count 1 \
     --instance-type t3.xlarge \
-    --key-name joker \
-    --security-group-ids sg-joker \
-    --subnet-id subnet-joker \
-    --block-device-mappings "[{\"DeviceName\":\"/dev/sdf\",\"Ebs\":{\"SnapshotId\":\"snap-joker\"}}]" \
+    --key-name example \
+    --security-group-ids sg-example \
+    --subnet-id subnet-example \
+    --block-device-mappings "[{\"DeviceName\":\"/dev/sdf\",\"Ebs\":{\"SnapshotId\":\"snap-example\"}}]" \
     --user-data file://cloud-config.yml
 ```
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -10,10 +10,20 @@ file is required.
 
 ## Workflow
 
-The following AWS CLI command will instantiate the EC2 instance. You will have
-to substitute your own key name, security group, subnet ID, and snapshot ID.
+The following AWS CLI command will instantiate the EC2 instance. 
+
+If desired, you can update the substituions supplied to `sed` to change the SHA
+of this repository that is checked out, and supply additional parameters to the
+`osmx-update` command.
+
+You will have to substitute your own key name, security group, subnet ID, and
+snapshot ID.
 
 ```bash
+sed -e "s/%%GIT_COMMIT%%/master/" \
+    -e "s/%%OSMX_UPDATE_OPTS%%//" \
+    "cloud-config.yml.template" > cloud-config.yml
+
 aws ec2 run-instances \
     --image-id ami-0bcc094591f354be2 \
     --count 1 \

--- a/deployment/cloud-config.yml
+++ b/deployment/cloud-config.yml
@@ -1,0 +1,27 @@
+#cloud-config
+mounts:
+- [ /dev/nvme0n1p1, /mnt/data/ ]
+
+packages:
+# These dependencies are nessecary to build Onramp Python dependencies
+- build-essential
+- python3-dev
+# For isolating Onramp build dependencies
+- python3-venv
+
+runcmd:
+# Install OSMExpress
+- curl -L https://github.com/protomaps/OSMExpress/releases/download/0.2.0/osmexpress-0.2.0-Linux.tgz | tar -xzC /usr/local/bin/ osmx
+# Clone Onramp
+- git clone https://github.com/azavea/onramp.git /opt/onramp 
+- sudo chown -R ubuntu:ubuntu /opt/onramp/
+- cd /opt/onramp/app
+# Install Python dependencies
+- python3 -m venv ./venv
+- sudo chown -R ubuntu:ubuntu ./venv
+- ./venv/bin/pip install wheel
+- ./venv/bin/pip install -r requirements.txt
+# Initial invocation of osmx-update
+- su - ubuntu -c "/opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update"
+# Write crontab entry to invoke osmx-update every minute
+- echo "* * * * * ubuntu /opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update" >>/etc/crontab

--- a/deployment/cloud-config.yml.template
+++ b/deployment/cloud-config.yml.template
@@ -16,12 +16,12 @@ runcmd:
 - git clone https://github.com/azavea/onramp.git /opt/onramp 
 - sudo chown -R ubuntu:ubuntu /opt/onramp/
 - cd /opt/onramp/app
+- git checkout %%GIT_COMMIT%%
 # Install Python dependencies
-- python3 -m venv ./venv
-- sudo chown -R ubuntu:ubuntu ./venv
+- su - ubuntu -c "python3 -m venv ./venv"
 - ./venv/bin/pip install wheel
 - ./venv/bin/pip install -r requirements.txt
 # Initial invocation of osmx-update
-- su - ubuntu -c "/opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update"
+- su - ubuntu -c "/opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update %%OSMX_UPDATE_OPTS%% /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update"
 # Write crontab entry to invoke osmx-update every minute
-- echo "* * * * * ubuntu /opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update" >>/etc/crontab
+- echo "* * * * * ubuntu /opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update %%OSMX_UPDATE_OPTS%% /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update" >>/etc/crontab

--- a/deployment/cloud-config.yml.template
+++ b/deployment/cloud-config.yml.template
@@ -3,7 +3,7 @@ mounts:
 - [ /dev/nvme0n1p1, /mnt/data/ ]
 
 packages:
-# These dependencies are nessecary to build Onramp Python dependencies
+# These dependencies are necessary to build Onramp Python dependencies
 - build-essential
 - python3-dev
 # For isolating Onramp build dependencies


### PR DESCRIPTION
## Overview

This PR adds cloud-init directives to mount an EBS volume containing the existing `planet.osmx` database file, install prebuilt binaries of OSMExpress, clone this repository, and start invoking `osmx-update` every minute.

In addition, I drafted instructions for instantiating the EC2 instance with the cloud-config as [user data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html).

Resolves #24 

## Testing Instructions

I followed the instructions in the deployment README to instantiate an EC2 instance.

```bash
[rocky@algiers deployment] (jrb/deployment)$ aws ec2 run-instances \
    --image-id ami-0bcc094591f354be2 \
    --count 1 \
    --instance-type t3.xlarge \
    --key-name <keypairname> \
    --security-group-ids sg-6b227c23 \
    --subnet-id subnet-973597bd \
    --block-device-mappings "[{\"DeviceName\":\"/dev/sdf\",\"Ebs\":{\"SnapshotId\":\"snap-06740aa4c98af65bd\"}}]" \
    --user-data file://cloud-config.yml
. . .
```

You can tail the output of the cloud-init to see that the execution is successful.

```bash
$ tail -f /var/log/cloud-init-output.log
. . .
```

You can also tail syslog to see `osmx-update` at work.

```bash
$ tail -f /var/log/syslog
Sep  1 00:08:01 ip-10-0-1-70 CRON[17082]: (ubuntu) CMD (/opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update)
Sep  1 00:08:01 ip-10-0-1-70 osmx-update: Process is running - exiting.
Sep  1 00:09:01 ip-10-0-1-70 CRON[17094]: (ubuntu) CMD (/opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update)
Sep  1 00:09:14 ip-10-0-1-70 osmx-update: Committed: 3985457 -> 3985458 in 11.657 seconds.
Sep  1 00:09:31 ip-10-0-1-70 osmx-update: Committed: 3985458 -> 3985459 in 16.683 seconds.
Sep  1 00:09:53 ip-10-0-1-70 osmx-update: Committed: 3985459 -> 3985460 in 21.237 seconds.
Sep  1 00:10:01 ip-10-0-1-70 CRON[17121]: (ubuntu) CMD (/opt/onramp/app/venv/bin/python /opt/onramp/app/osmx-update /mnt/data/planet.osmx https://planet.openstreetmap.org/replication/minute/ 2>&1 | /usr/bin/logger -t osmx-update)
Sep  1 00:10:01 ip-10-0-1-70 osmx-update: Process is running - exiting.
Sep  1 00:10:19 ip-10-0-1-70 osmx-update: Committed: 3985460 -> 3985461 in 24.931 seconds.
Sep  1 00:10:42 ip-10-0-1-70 osmx-update: Committed: 3985461 -> 3985462 in 22.085 seconds.
```
