### PR TITLE
Initial attempt to validate Onramp diffs against Overpass

### DIFF
--- a/app/onramp/diff.py
+++ b/app/onramp/diff.py
@@ -66,8 +66,17 @@ def indent(elem, level=0):
             elem.tail = i
 
 
-def augmented_diff(osmx_file, osc_file, output_file, end_timestamp):
+def augmented_diff(
+    osmx_file,
+    osc_file,
+    output_file,
+    end_timestamp=None,
+    osc_sequence=None,
+    osc_url=None,
+):
     """ Generate an OSM Augmented Diff using osmx_file and osc_file
+
+    end_timestamp is the timestamp of the end of the time range in the osc_file.
 
     Result written as xml to output_file, which can be a local file or S3 URI.
 
@@ -405,7 +414,18 @@ def augmented_diff(osmx_file, osc_file, output_file, end_timestamp):
     o[:] = sorted(o, key=sort_by_type)
 
     meta = ET.Element("meta")
-    meta.set("osm_base", end_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    if end_timestamp is not None:
+        meta.set("osm_base", end_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    else:
+        logger.warning("No end_timestamp provided, cannot set meta.osm_base!")
+    if osc_sequence is not None:
+        meta.set("replication_id", str(osc_sequence))
+    else:
+        logger.warning("No osc_sequence provided, cannot set meta.replication_id!")
+    if osc_url is not None:
+        meta.set("replication_url", str(osc_url))
+    else:
+        logger.warning("No osc_url provided, cannot set meta.replication_url!")
     o.insert(0, meta)
 
     note = ET.Element("note")

--- a/app/osmx-update
+++ b/app/osmx-update
@@ -38,7 +38,9 @@ def datetime_to_adiff_sequence(datetime):
     return int(floor((int(query) - 1347432900) / 60))
 
 
-def generate_augmented_diff(osmosis_state, osmx_db, osc_gz_file, output_path):
+def generate_augmented_diff(
+    osmosis_state, osmx_db, osc_gz_file, output_path, replication_server_url
+):
     """ Generate an augmented diff for changes between osmx_db and osc_gz_file.
 
     osmosis_state should be the state matching the osc_gz_file
@@ -47,6 +49,8 @@ def generate_augmented_diff(osmosis_state, osmx_db, osc_gz_file, output_path):
 
     augmented diff is written to:
     output_path/adiff_seq_id[0:3]/adiff_seq_id[3:6]/adiff_seq_id[6:9].adiff.xml
+    By converting osmosis_state.timestamp to minutely adiff_seq_id via
+    datetime_to_adiff_sequence().
 
     output_path can be a local file path or an s3 uri.
 
@@ -55,14 +59,21 @@ def generate_augmented_diff(osmosis_state, osmx_db, osc_gz_file, output_path):
     current_id = osmosis_state.sequence
     adiff_seq_id = datetime_to_adiff_sequence(osmosis_state.timestamp)
     logger.debug(
-        "OSM Change Sequence Id {} -> Minutely Augmented Diff Id {}".format(
-            current_id, adiff_seq_id
+        "OSM Change Sequence Id {} @ {} -> Minutely Augmented Diff Id {}".format(
+            current_id, osmosis_state.timestamp, adiff_seq_id
         )
     )
     [pt1, pt2, pt3] = wrap(str(adiff_seq_id).zfill(9), 3)
     output_file = os.path.join(output_path, pt1, pt2, "{}.xml.gz".format(pt3))
     with gzip.open(osc_gz_file) as fp_unzipped:
-        augmented_diff(osmx_db, fp_unzipped, output_file, osmosis_state.timestamp)
+        augmented_diff(
+            osmx_db,
+            fp_unzipped,
+            output_file,
+            end_timestamp=osmosis_state.timestamp,
+            osc_sequence=osmosis_state.sequence,
+            osc_url=replication_server_url,
+        )
     logger.info(
         "Augmented diff {} generated in {}s".format(
             adiff_seq_id, time.time() - adiff_start
@@ -121,7 +132,11 @@ def main():
 
             if args.augmented_diff is not None:
                 generate_augmented_diff(
-                    osmosis_state, args.osmx_db, fp.name, args.augmented_diff
+                    osmosis_state,
+                    args.osmx_db,
+                    fp.name,
+                    args.augmented_diff,
+                    args.replication_server,
                 )
 
             subprocess.check_call(

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -1,0 +1,192 @@
+import argparse
+from collections import Counter
+import gzip
+import json
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from textwrap import wrap
+from urllib.request import urlretrieve
+import xml.etree.ElementTree as ET
+
+
+def list_duplicates(elements):
+    """ Return list of elements that are visible more than once in the input elements. """
+    return [item for item, count in Counter(elements).items() if count > 1]
+
+
+def elements_equal(e1, e2):
+    """ Equality comparison for two xml.etree.ElementTree.Element
+
+    From https://stackoverflow.com/a/24349916
+
+    """
+    if e1.tag != e2.tag:
+        return False
+    if (
+        (
+            e1.text is not None
+            and e2.text is not None
+            and e1.text.strip() != e2.text.strip()
+        )
+        or (e1.text is None and e2.text is not None)
+        or (e1.text is not None and e2.text is None)
+    ):
+        return False
+    if (
+        (
+            e1.tail is not None
+            and e2.tail is not None
+            and e1.tail.strip() != e2.tail.strip()
+        )
+        or (e1.tail is None and e2.tail is not None)
+        or (e1.tail is not None and e2.tail is None)
+    ):
+        return False
+    if e1.attrib != e2.attrib:
+        return False
+    if len(e1) != len(e2):
+        return False
+    return all(elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
+
+
+def elements_from_root(root_element):
+    """ Retrieve list of unique tuples for each element
+
+    (
+        "create"|"modify"|"delete",
+        "old"|"new",
+        "node"|"way"|"relation",
+        object_id,
+        object_version
+    )
+
+    Boy this processing is a pain because create skips the intermediate
+    <old>|<new> element.
+
+    """
+    osm_types = set(["node", "way", "relation"])
+
+    elements = []
+    for action in root_element:
+        action_type = action.get("type")
+        if action_type is None:
+            continue
+
+        new = action.find("new")
+        old = action.find("old")
+        if new is not None:
+            elements += [
+                (action_type, "new", e.tag, e.get("id"), e.get("version"),)
+                for e in new
+                if e.tag in osm_types
+            ]
+        if old is not None:
+            elements += [
+                (action_type, "old", e.tag, e.get("id"), e.get("version"),)
+                for e in old
+                if e.tag in osm_types
+            ]
+        if new is None and old is None:
+            elements += [
+                (action_type, "new", e.tag, e.get("id"), e.get("version"),)
+                for e in action
+                if e.tag in osm_types
+            ]
+    return elements
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--augmented_diff_id", type=str)
+    parser.add_argument("--onramp-path", type=str)
+    parser.add_argument("--overpass-diff", type=Path, default=None)
+    parser.add_argument("--detailed", action="store_true")
+    args = parser.parse_args()
+
+    [pt1, pt2, pt3] = wrap(str(int(args.augmented_diff_id) + 1).zfill(9), 3)
+
+    # Load onramp diff from local path
+    onramp_path = os.path.join(args.onramp_path, pt1, pt2, "{}.xml.gz".format(pt3))
+    with gzip.open(onramp_path) as fp:
+        onramp_root_element = ET.parse(fp).getroot()
+    onramp_elements = elements_from_root(onramp_root_element)
+    onramp_elements_set = set(onramp_elements)
+    print("Loaded {} elements from {}...".format(len(onramp_elements_set), onramp_path))
+
+    # Pull, open and parse Overpass API augmented diff
+    overpass_root_element = None
+    if args.overpass_diff is not None:
+        overpass_root_element = ET.parse(str(args.overpass_diff)).getroot()
+    else:
+        overpass_url = "http://overpass-api.de/api/augmented_diff?id={}".format(
+            args.augmented_diff_id
+        )
+        with NamedTemporaryFile(delete=False) as fp:
+            print("Writing overpass diff to {}...".format(fp.name))
+            urlretrieve(overpass_url, fp.name)
+            overpass_root_element = ET.parse(fp.name).getroot()
+    overpass_elements = elements_from_root(overpass_root_element)
+    overpass_elements_set = set(overpass_elements)
+
+    results = {"both": {}, "onramp": {}, "overpass": {}}
+    # Set element counts
+    results["both"]["count"] = len(
+        onramp_elements_set.intersection(overpass_elements_set)
+    )
+    results["onramp"]["count"] = len(onramp_elements_set)
+    results["overpass"]["count"] = len(overpass_elements_set)
+
+    # Are onramp elements a subset of overpass?
+    results["onramp"]["is_subset"] = onramp_elements_set <= overpass_elements_set
+    # Elements in onramp that aren't in overpass
+    onramp_difference = onramp_elements_set.difference(overpass_elements_set)
+    # results["onramp"]["difference"] = list(onramp_difference)[:10]
+    # Count of elements in onramp that aren't in overpass
+    results["onramp"]["difference_count"] = len(onramp_difference)
+    # List duplicate elements
+    results["onramp"]["duplicates"] = list_duplicates(onramp_elements)
+
+    # Are overpass elements a subset of onramp?
+    results["overpass"]["is_subset"] = overpass_elements_set <= onramp_elements_set
+    # Elements in overpass that aren't in onramp
+    overpass_difference = overpass_elements_set.difference(onramp_elements_set)
+    # results["overpass"]["difference"] = list(overpass_difference)[:10]
+    # Count of elements in overpass that aren't in onramp
+    results["overpass"]["difference_count"] = len(overpass_difference)
+    # List duplicate elements
+    results["overpass"]["duplicates"] = list_duplicates(overpass_elements)
+
+    # Print comparison summary
+    print(json.dumps(results, indent=2))
+
+    intersection = onramp_elements_set.intersection(overpass_elements_set)
+    if args.detailed:
+        equal_elements = set()
+        for element in intersection:
+            onramp_element = onramp_root_element.find(
+                "./action[@type='{}']/{}/{}[@id='{}'][@version='{}']".format(*element)
+            )
+            overpass_element = overpass_root_element.find(
+                "./action[@type='{}']/{}/{}[@id='{}'][@version='{}']".format(*element)
+            )
+            if overpass_element is None:
+                # Try again for create ops which don't have the intermediate 'new/old' element
+                overpass_element = overpass_root_element.find(
+                    "./action[@type='{}']/{}[@id='{}'][@version='{}']".format(
+                        element[0], element[2], element[3], element[4]
+                    )
+                )
+            if (
+                onramp_element is not None
+                and overpass_element is not None
+                and elements_equal(onramp_element, overpass_element)
+            ):
+                equal_elements.add(element)
+
+        print("{}/{} elements are equal".format(len(equal_elements), len(intersection)))
+        print(equal_elements)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The validation script in here can only really be used on a local gzipped onramp diff compared against a remote Overpass diff, but it does work, and it shows a summary of some metrics including the number of "unique" elements that intersect between the two. As of now, it doesn't make any statements about whether the contents of each unique element are the same, but there's some work down in the `if args.detailed` section that begins to dig at that question. I did enough digging to open 4 new high priority bugs to address before moving forward with additional validation. 

Merging this now because it's useful to make available and there's another commit that improves the meta reporting in the onramp generated diff to include the osc url and id the diff was generated from, which should aid in future validation, auditing and debugging efforts.