### PR TITLE
Nest created OSM elements directly under the action element

### DIFF
--- a/tests/validate.py
+++ b/tests/validate.py
@@ -104,7 +104,7 @@ def main():
     parser.add_argument("--detailed", action="store_true")
     args = parser.parse_args()
 
-    [pt1, pt2, pt3] = wrap(str(int(args.augmented_diff_id) + 1).zfill(9), 3)
+    [pt1, pt2, pt3] = wrap(str(int(args.augmented_diff_id)).zfill(9), 3)
 
     # Load onramp diff from local path
     onramp_path = os.path.join(args.onramp_path, pt1, pt2, "{}.xml.gz".format(pt3))
@@ -164,17 +164,26 @@ def main():
     if args.detailed:
         equal_elements = set()
         for element in intersection:
-            onramp_element = onramp_root_element.find(
-                "./action[@type='{}']/{}/{}[@id='{}'][@version='{}']".format(*element)
-            )
-            overpass_element = overpass_root_element.find(
-                "./action[@type='{}']/{}/{}[@id='{}'][@version='{}']".format(*element)
-            )
-            if overpass_element is None:
-                # Try again for create ops which don't have the intermediate 'new/old' element
+            if element[0] == "create":
+                onramp_element = onramp_root_element.find(
+                    "./action[@type='{}']/{}[@id='{}'][@version='{}']".format(
+                        element[0], element[2], element[3], element[4]
+                    )
+                )
                 overpass_element = overpass_root_element.find(
                     "./action[@type='{}']/{}[@id='{}'][@version='{}']".format(
                         element[0], element[2], element[3], element[4]
+                    )
+                )
+            else:
+                onramp_element = onramp_root_element.find(
+                    "./action[@type='{}']/{}/{}[@id='{}'][@version='{}']".format(
+                        *element
+                    )
+                )
+                overpass_element = overpass_root_element.find(
+                    "./action[@type='{}']/{}/{}[@id='{}'][@version='{}']".format(
+                        *element
                     )
                 )
             if (
@@ -184,8 +193,8 @@ def main():
             ):
                 equal_elements.add(element)
 
+        # print(equal_elements)
         print("{}/{} elements are equal".format(len(equal_elements), len(intersection)))
-        print(equal_elements)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
...omitting the intermediate, redundant `<new>` element. This PR updates Onramp to match the XML format of the Overpass augmented diffs exactly.

Summary of changes:
- Refactor main if/elif/else statement in second pass to flatten it out, hopefully clarifying order of operations and the available branches
- Refactor `augment` method to take the osm element directly, instead of the `old|new` element. Reduces a layer of indirection, call sites updated.
- Refactor main loops and the sort methods to branch on action type == create in all the necessary places.

## Demo

With these changes in place, running our new `./tests/validate.py` script on the same onramp diff generated with this branch and master, we have the same summary stats printed and we bumped our equal elements count by ~100:

### Result of comparison between Onramp and Overpass diffs for sequence id 4215595 run on `master` branch

![Screen Shot 2020-09-22 at 2 28 18 PM](https://user-images.githubusercontent.com/1818302/93922906-9ae82380-fce0-11ea-836b-4cd06d19ca4d.png)

### Result of comparison between Onramp and Overpass diffs for sequence id 4215595 run on this branch

![Screen Shot 2020-09-22 at 2 28 06 PM](https://user-images.githubusercontent.com/1818302/93922931-a50a2200-fce0-11ea-99ec-d0191b06fdb1.png)
