### PR TITLE
Compute bounding boxes for both old and new elements

### DIFF
--- a/app/onramp/diff.py
+++ b/app/onramp/diff.py
@@ -394,13 +394,17 @@ def augmented_diff(
     # 5th pass: add bounding boxes
     for child in o:
         if len(child[0]) > 0:
-            osm_obj = child[0] if child.get("type") == "create" else child[0][0]
-            nds = osm_obj.findall(".//nd")
-            if nds:
-                bounds = Bounds()
-                for nd in nds:
-                    bounds.add(float(nd.get("lon")), float(nd.get("lat")))
-                osm_obj.insert(0, bounds.elem())
+            if child.get("type") == "create":
+                osm_objs = [child[0]]
+            else:
+                osm_objs = [child[0][0], child[1][0]]
+            for osm_obj in osm_objs:
+                nds = osm_obj.findall(".//nd")
+                if nds:
+                    bounds = Bounds()
+                    for nd in nds:
+                        bounds.add(float(nd.get("lon")), float(nd.get("lat")))
+                    osm_obj.insert(0, bounds.elem())
 
     # 6th pass
     # sort by node, way, relation


### PR DESCRIPTION
Bounds elements are now computed for both old and new versions of each OSM element in the augmented diff.

Opened follow up issue #46 to address later, as its not critical if this is exactly correct for our use case.

## Demo

![Screen Shot 2020-09-22 at 3 05 27 PM](https://user-images.githubusercontent.com/1818302/93927134-73945500-fce6-11ea-975d-7eeddb59a724.png)
![Screen Shot 2020-09-22 at 3 05 52 PM](https://user-images.githubusercontent.com/1818302/93927137-742ceb80-fce6-11ea-9780-1677a463ffca.png)
