### PR TITLE
Write status.txt to augmented diff output dir

### DIFF
--- a/app/onramp/__init__.py
+++ b/app/onramp/__init__.py
@@ -1,1 +1,37 @@
-from .diff import augmented_diff
+from io import BytesIO
+from math import floor
+import os
+from urllib.parse import urlparse
+
+import boto3
+
+from .diff import augmented_diff  # noqa: F401
+
+
+def datetime_to_adiff_sequence(datetime):
+    """ Convert a timezone aware datetime to minutely augmented diff sequence id. """
+    if datetime.tzinfo is None:
+        raise ValueError("Datetime {} must be timezone aware".format(datetime))
+    query = datetime.timestamp()
+    return int(floor((int(query) - 1347432960) / 60))
+
+
+def write_augmented_diff_status(output_path, sequence_id):
+    """ Write status.txt containing the sequence_id to output_path/state.txt
+
+    Supports s3 and local filesystem paths.
+
+    """
+    status_filename = "status.txt"
+    if output_path.startswith("s3"):
+        url = urlparse(output_path)
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(url.netloc)
+        with BytesIO() as fp:
+            fp.write(str(sequence_id).encode("utf-8"))
+            fp.seek(0)
+            key_path = os.path.join(url.path.strip("/"), status_filename)
+            bucket.upload_fileobj(fp, key_path, {"ContentType": "text/plain"})
+    else:
+        with open(os.path.join(output_path, status_filename), "w") as fp:
+            fp.write(str(sequence_id))

--- a/app/osmx-update
+++ b/app/osmx-update
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 import fcntl
 import gzip
 import logging
-from math import floor
 import os
 import subprocess
 import sys
@@ -18,7 +17,11 @@ from tempfile import NamedTemporaryFile
 from textwrap import wrap
 import time
 
-from onramp import augmented_diff
+from onramp import (
+    augmented_diff,
+    datetime_to_adiff_sequence,
+    write_augmented_diff_status,
+)
 from server import ReplicationServer
 
 # expects osmx to be on the PATH.
@@ -28,14 +31,6 @@ osmx = "osmx"
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
-
-
-def datetime_to_adiff_sequence(datetime):
-    """ Convert a timezone aware datetime to minutely augmented diff sequence id. """
-    if datetime.tzinfo is None:
-        raise ValueError("Datetime {} must be timezone aware".format(datetime))
-    query = datetime.timestamp()
-    return int(floor((int(query) - 1347432960) / 60))
 
 
 def generate_augmented_diff(
@@ -74,6 +69,7 @@ def generate_augmented_diff(
             osc_sequence=osmosis_state.sequence,
             osc_url=replication_server_url,
         )
+    write_augmented_diff_status(output_path, adiff_seq_id)
     logger.info(
         "Augmented diff {} generated in {}s".format(
             adiff_seq_id, time.time() - adiff_start


### PR DESCRIPTION
Contains the current sequence id so that applications
can determine the head of the stream.

Analogous to Overpass API /api/augmented_diff_status
endpoint.