### PR TITLE
Augment deleted elements in diff

### DIFF
--- a/app/onramp/diff.py
+++ b/app/onramp/diff.py
@@ -41,10 +41,10 @@ class Bounds:
 
     def elem(self):
         e = ET.Element("bounds")
-        e.set("minlat", str(self.miny))
-        e.set("minlon", str(self.minx))
-        e.set("maxlat", str(self.maxy))
-        e.set("maxlon", str(self.maxx))
+        e.set("minlat", "{:.07f}".format(self.miny))
+        e.set("minlon", "{:.07f}".format(self.minx))
+        e.set("maxlat", "{:.07f}".format(self.maxy))
+        e.set("maxlon", "{:.07f}".format(self.maxx))
         return e
 
 
@@ -131,10 +131,12 @@ def augmented_diff(
         def get_lat_lon(ref, use_new):
             if use_new and ("node/" + ref in actions):
                 node = actions["node/" + ref]
-                return (node.element.get("lon"), node.element.get("lat"))
+                lon = "{:.07f}".format(float(node.element.get("lon")))
+                lat = "{:.07f}".format(float(node.element.get("lat")))
+                return (lon, lat)
             else:
                 ll = locations.get(ref)
-                return (str(ll[1]), str(ll[0]))
+                return ("{:.07f}".format(ll[1]), "{:.07f}".format(ll[0]))
 
         def rebuild_old_element(elem):
             elem_id = int(elem.get("id"))

--- a/app/onramp/diff.py
+++ b/app/onramp/diff.py
@@ -136,14 +136,36 @@ def augmented_diff(
                 ll = locations.get(ref)
                 return (str(ll[1]), str(ll[0]))
 
-        def set_old_metadata(elem):
+        def rebuild_old_element(elem):
             elem_id = int(elem.get("id"))
             if elem.tag == "node":
                 o = nodes.get(elem_id)
+                ll = get_lat_lon(elem_id, False)
+                elem.set("lon", ll[0])
+                elem.set("lat", ll[1])
             elif elem.tag == "way":
                 o = ways.get(elem_id)
+                for n in o.nodes:
+                    node = ET.SubElement(elem, "nd")
+                    node.set("ref", str(n))
+                it = iter(o.tags)
+                for t in it:
+                    tag = ET.SubElement(elem, "tag")
+                    tag.set("k", t)
+                    tag.set("v", next(it))
             else:
                 o = relations.get(elem_id)
+                for m in o.members:
+                    member = ET.SubElement(elem, "member")
+                    member.set("ref", str(m.ref))
+                    member.set("role", m.role)
+                    member.set("type", str(m.type))
+                it = iter(o.tags)
+                for t in it:
+                    tag = ET.SubElement(elem, "tag")
+                    tag.set("k", t)
+                    tag.set("v", next(it))
+
             if o:
                 elem.set("version", str(o.metadata.version))
                 elem.set("user", str(o.metadata.user))
@@ -190,7 +212,7 @@ def augmented_diff(
                 new = ET.SubElement(a, "new")
                 # get the old metadata
                 modified = copy.deepcopy(action.element)
-                set_old_metadata(action.element)
+                rebuild_old_element(action.element)
                 old.append(action.element)
 
                 modified.set("visible", "false")
@@ -218,33 +240,7 @@ def augmented_diff(
                 new = ET.SubElement(a, "new")
                 prev_version = ET.SubElement(old, action.element.tag)
                 prev_version.set("id", obj_id)
-                set_old_metadata(prev_version)
-                if action.element.tag == "node":
-                    ll = get_lat_lon(obj_id, False)
-                    prev_version.set("lon", ll[0])
-                    prev_version.set("lat", ll[1])
-                elif action.element.tag == "way":
-                    way = ways.get(obj_id)
-                    for n in way.nodes:
-                        node = ET.SubElement(prev_version, "nd")
-                        node.set("ref", str(n))
-                    it = iter(way.tags)
-                    for t in it:
-                        tag = ET.SubElement(prev_version, "tag")
-                        tag.set("k", t)
-                        tag.set("v", next(it))
-                else:
-                    relation = relations.get(obj_id)
-                    for m in relation.members:
-                        member = ET.SubElement(prev_version, "member")
-                        member.set("ref", str(m.ref))
-                        member.set("role", m.role)
-                        member.set("type", str(m.type))
-                    it = iter(relation.tags)
-                    for t in it:
-                        tag = ET.SubElement(prev_version, "tag")
-                        tag.set("k", t)
-                        tag.set("v", next(it))
+                rebuild_old_element(prev_version)
                 new.append(action.element)
 
         # 3rd pass
@@ -343,16 +339,7 @@ def augmented_diff(
             old = ET.SubElement(a, "old")
             way_element = ET.SubElement(old, "way")
             way_element.set("id", str(w))
-            set_old_metadata(way_element)
-            way = ways.get(w)
-            for n in way.nodes:
-                node = ET.SubElement(way_element, "nd")
-                node.set("ref", str(n))
-            it = iter(way.tags)
-            for t in it:
-                tag = ET.SubElement(way_element, "tag")
-                tag.set("k", t)
-                tag.set("v", next(it))
+            rebuild_old_element(way_element)
 
             new = ET.SubElement(a, "new")
             new_elem = copy.deepcopy(way_element)
@@ -364,19 +351,7 @@ def augmented_diff(
             old = ET.Element("old")
             relation_element = ET.SubElement(old, "relation")
             relation_element.set("id", str(r))
-            set_old_metadata(relation_element)
-            relation = relations.get(r)
-
-            for m in relation.members:
-                member = ET.SubElement(relation_element, "member")
-                member.set("ref", str(m.ref))
-                member.set("role", m.role)
-                member.set("type", str(m.type))
-            it = iter(relation.tags)
-            for t in it:
-                tag = ET.SubElement(relation_element, "tag")
-                tag.set("k", t)
-                tag.set("v", next(it))
+            rebuild_old_element(relation_element)
 
             new_elem = copy.deepcopy(relation_element)
             new = ET.Element("new")
@@ -384,6 +359,7 @@ def augmented_diff(
             try:
                 augment(relation_element, False)
                 augment(new_elem, True)
+
                 a = ET.SubElement(o, "action")
                 a.set("type", "modify")
                 a.append(old)

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -144,6 +144,7 @@ def main():
     intersection = onramp_elements_set.intersection(overpass_elements_set)
     if args.detailed:
         equal_elements = set()
+        different_elements = set()
         for element in intersection:
             if element[0] == "create":
                 onramp_element = onramp_root_element.find(
@@ -173,9 +174,13 @@ def main():
                 and elements_equal(onramp_element, overpass_element)
             ):
                 equal_elements.add(element)
+            else:
+                # print(element)
+                different_elements.add(element)
 
         # print(equal_elements)
         print("{}/{} elements are equal".format(len(equal_elements), len(intersection)))
+        print("Different: {}".format(list(different_elements)[:20]))
 
 
 if __name__ == "__main__":

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -2,11 +2,7 @@ import argparse
 from collections import Counter
 import gzip
 import json
-import os
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from textwrap import wrap
-from urllib.request import urlretrieve
 import xml.etree.ElementTree as ET
 
 
@@ -98,34 +94,19 @@ def elements_from_root(root_element):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-a", "--augmented_diff_id", type=str)
-    parser.add_argument("--onramp-path", type=str)
+    parser.add_argument("--onramp-diff", type=str)
     parser.add_argument("--overpass-diff", type=Path, default=None)
     parser.add_argument("--detailed", action="store_true")
     args = parser.parse_args()
 
-    [pt1, pt2, pt3] = wrap(str(int(args.augmented_diff_id)).zfill(9), 3)
-
     # Load onramp diff from local path
-    onramp_path = os.path.join(args.onramp_path, pt1, pt2, "{}.xml.gz".format(pt3))
-    with gzip.open(onramp_path) as fp:
+    with gzip.open(args.onramp_diff) as fp:
         onramp_root_element = ET.parse(fp).getroot()
     onramp_elements = elements_from_root(onramp_root_element)
     onramp_elements_set = set(onramp_elements)
-    print("Loaded {} elements from {}...".format(len(onramp_elements_set), onramp_path))
 
-    # Pull, open and parse Overpass API augmented diff
-    overpass_root_element = None
-    if args.overpass_diff is not None:
-        overpass_root_element = ET.parse(str(args.overpass_diff)).getroot()
-    else:
-        overpass_url = "http://overpass-api.de/api/augmented_diff?id={}".format(
-            args.augmented_diff_id
-        )
-        with NamedTemporaryFile(delete=False) as fp:
-            print("Writing overpass diff to {}...".format(fp.name))
-            urlretrieve(overpass_url, fp.name)
-            overpass_root_element = ET.parse(fp.name).getroot()
+    # Open and parse Overpass API augmented diff
+    overpass_root_element = ET.parse(str(args.overpass_diff)).getroot()
     overpass_elements = elements_from_root(overpass_root_element)
     overpass_elements_set = set(overpass_elements)
 


### PR DESCRIPTION
## Notes

Other changes:
- Use exactly 7 decimal points for node lat lons to match osmium convention
- Simplify args to test/validate.py -- now just directly pass the xml files to be compared

## Testing

I ran this through validate.py and bumped the number of equivalent elements by ~1000 for the augmented diff 4215817.

I also ran the output of this through the branches for https://github.com/azavea/osm-replication-streams/pull/6 and https://github.com/azavea/overpass-diff-publisher/pull/1. This PR fixes the error I was seeing in https://github.com/azavea/overpass-diff-publisher/pull/1 

Closes #49 