### PR TITLE
Include node tags in modify/delete actions

### DIFF
--- a/app/onramp/diff.py
+++ b/app/onramp/diff.py
@@ -100,6 +100,12 @@ def augmented_diff(
             elem_id = int(elem.get("id"))
             if elem.tag == "node":
                 o = nodes.get(elem_id)
+                if o is not None:
+                    it = iter(o.tags)
+                    for t in it:
+                        tag = ET.SubElement(elem, "tag")
+                        tag.set("k", t)
+                        tag.set("v", next(it))
             elif elem.tag == "way":
                 o = ways.get(elem_id)
                 for n in o.nodes:


### PR DESCRIPTION
A slight oversight led to tagged nodes having their tags omitted in `<old>` subblocks of `delete` and `modify` `<action>` blocks.  This caused some problems for client applications (notably stats calculations in OSMesa).  This fix has been tested in detail, and found to produce the correct results for a test deployment.